### PR TITLE
Update apicurio to 1.3.2

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -30,13 +30,8 @@ services:
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
 
   schema-registry:
-    image: apicurio/apicurio-registry-mem:1.2.2.Final
+    image: apicurio/apicurio-registry-mem:1.3.2.Final
     ports:
       - 8081:8080
-    depends_on:
-      - kafka
     environment:
       QUARKUS_PROFILE: prod
-      KAFKA_BOOTSTRAP_SERVERS: localhost:9092
-      APPLICATION_ID: registry_id
-      APPLICATION_SERVER: localhost:9000

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,8 @@
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
     <quarkus.platform.version>1.10.2.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
-    <apicurio.version>1.2.2.Final</apicurio.version>
+    <apicurio.version>1.3.2.Final</apicurio.version>
+    <quarkiverse.apicurio.version>0.0.1</quarkiverse.apicurio.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -56,6 +57,12 @@
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-avro</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.quarkiverse.apicurio</groupId>
+      <artifactId>quarkiverse-apicurio-registry-client</artifactId>
+      <version>${quarkiverse.apicurio.version}</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Updates the version of apicurio used in docker-compose and in the pom.xml, also adds the dependency to the new apicurio-registry-client quarkus extension, allowing to compile to native